### PR TITLE
modify python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,9 @@ jobs:
 
     - name: Install Python 2.x
       if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'macos-latest'
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
-        python-version: '2.x'
+        python-version: '2.7'
 
     - name: Install dependencies (ubuntu)
       if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'ubuntu-latest'


### PR DESCRIPTION
The workflow has stopped working for some time, because Python was not successfully installed and vs version > 2019.

https://github.com/go-flutter-desktop/engine-builds/actions



I modified the version of Python and the build seems to work correctly

https://github.com/niuhuan/flutter-engine-builds/actions/runs/1926631066
