### PR TITLE
Fix CI to continue generating builds

### DIFF
--- a/embedder.patch
+++ b/embedder.patch
@@ -1,0 +1,70 @@
+diff --git shell/platform/embedder/BUILD.gn shell/platform/embedder/BUILD.gn
+index b54a0d25a5..c811b9b520 100644
+--- shell/platform/embedder/BUILD.gn
++++ shell/platform/embedder/BUILD.gn
+@@ -324,7 +324,7 @@ copy("copy_headers") {
+   outputs = [ "$root_out_dir/flutter_embedder.h" ]
+ }
+ 
+-if (is_mac && !embedder_for_target) {
++if (is_mac) {
+   _flutter_embedder_framework_dir = "$root_out_dir/FlutterEmbedder.framework"
+ 
+   copy("copy_framework_headers") {
+@@ -412,29 +412,7 @@ if (is_mac && !embedder_for_target) {
+     visibility = [ ":*" ]
+     deps = [ ":generate_symlinks" ]
+   }
+-}
+-
+-group("flutter_engine") {
+-  deps = []
+-
+-  build_embedder_api =
+-      current_toolchain == host_toolchain || embedder_for_target
+-
+-  if (build_embedder_api) {
+-    # All platforms require the embedder dylib and headers.
+-    deps += [
+-      ":copy_headers",
+-      ":flutter_engine_library",
+-    ]
+-
+-    # For the Mac, the dylib is packaged in a framework with the appropriate headers.
+-    if (is_mac && !embedder_for_target) {
+-      deps += [ ":flutter_embedder_framework" ]
+-    }
+-  }
+-}
+ 
+-if (is_mac) {
+   zip_bundle("flutter_embedder_framework_archive") {
+     deps = [ ":generate_symlinks" ]
+     output = "$full_platform_name/FlutterEmbedder.framework.zip"
+@@ -459,6 +437,26 @@ if (is_mac) {
+   }
+ }
+ 
++group("flutter_engine") {
++  deps = []
++
++  build_embedder_api =
++      current_toolchain == host_toolchain || embedder_for_target
++
++  if (build_embedder_api) {
++    # All platforms require the embedder dylib and headers.
++    deps += [
++      ":copy_headers",
++      ":flutter_engine_library",
++    ]
++
++    # For the Mac, the dylib is packaged in a framework with the appropriate headers.
++    if (is_mac && !embedder_for_target) {
++      deps += [ ":flutter_embedder_framework" ]
++    }
++  }
++}
++
+ if (host_os == "linux" || host_os == "win") {
+   zip_bundle("embedder-archive") {
+     output = "$full_platform_name/$full_platform_name-embedder.zip"

--- a/main.gn
+++ b/main.gn
@@ -40,6 +40,10 @@ config("export_dynamic_symbols") {
 
 }
 
+group("dart_sdk") {
+
+}
+
 group("dist") {
   testonly = true
 

--- a/patch-engine.sh
+++ b/patch-engine.sh
@@ -9,4 +9,6 @@ echo "
 INCBIN(Icudtl, \"${PWD}/engine/src/third_party/icu/flutter/icudtl.dat\");
 " >> engine/src/flutter/shell/platform/embedder/embedder.cc
 cp switches.patch engine/src/flutter/shell/common/
-cd engine/src/flutter/shell/common && patch -i switches.patch
+(cd engine/src/flutter/shell/common && patch -i switches.patch)
+cp embedder.patch engine/src/flutter/shell/platform/embedder/
+(cd engine/src/flutter/shell/platform/embedder/ && patch -i embedder.patch)


### PR DESCRIPTION
The build has been broken for the last few months since the build files changed upstream.

This PR introduces fixes to reflect those changes. Ideally, a few of those changes would be done in `flutter/engine` itself, but it's proposed on this repo to reestablish the CI faster, and produce valid artifacts once again