### PR TITLE
ci: fix broken windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: Flutter Engine
 
-
 on:
   schedule:
-  - cron: 24 0/12 * * *
+    - cron: 24 0/12 * * *
   workflow_dispatch:
 
 jobs:
@@ -13,33 +12,33 @@ jobs:
       matrix:
         channel: [stable, beta] # master
         config:
-        # Debug builds not needed: fetched from Google
+          # Debug builds not needed: fetched from Google
 
-        - tag: host_profile
-          gn: --embedder-for-target --runtime-mode profile --lto
-          host: ubuntu-latest
-          host_tag: linux_x64
-        - tag: host_profile
-          gn: --embedder-for-target --runtime-mode profile --lto
-          host: macos-latest
-          host_tag: macosx_x64
-        - tag: host_profile
-          gn: --embedder-for-target --runtime-mode profile --lto
-          host: windows-2019
-          host_tag: windows_x64
+          - tag: host_profile
+            gn: --embedder-for-target --runtime-mode profile --lto
+            host: ubuntu-latest
+            host_tag: linux_x64
+          - tag: host_profile
+            gn: --embedder-for-target --runtime-mode profile --lto
+            host: macos-latest
+            host_tag: macosx_x64
+          - tag: host_profile
+            gn: --embedder-for-target --runtime-mode profile --lto
+            host: windows-2019
+            host_tag: windows_x64
 
-        - tag: host_release
-          gn: --embedder-for-target --runtime-mode release --lto --stripped
-          host: ubuntu-latest
-          host_tag: linux_x64
-        - tag: host_release
-          gn: --embedder-for-target --runtime-mode release --lto --stripped
-          host: macos-latest
-          host_tag: macosx_x64
-        - tag: host_release
-          gn: --embedder-for-target --runtime-mode release --lto --stripped
-          host: windows-2019
-          host_tag: windows_x64
+          - tag: host_release
+            gn: --embedder-for-target --runtime-mode release --lto --stripped
+            host: ubuntu-latest
+            host_tag: linux_x64
+          - tag: host_release
+            gn: --embedder-for-target --runtime-mode release --lto --stripped
+            host: macos-latest
+            host_tag: macosx_x64
+          - tag: host_release
+            gn: --embedder-for-target --runtime-mode release --lto --stripped
+            host: windows-2019
+            host_tag: windows_x64
 
     runs-on: ${{ matrix.config.host }}
 
@@ -50,185 +49,185 @@ jobs:
       PYTHONLEGACYWINDOWSSTDIO: utf-8
 
     steps:
-    - name: Free up space
-      if: matrix.config.host == 'ubuntu-latest'
-      run: |
-        pwd
-        sudo df -h
-        sudo find /opt -maxdepth 1 ! -name hostedtoolcache ! -name opt | sudo xargs rm -rf
-        sudo rm -rf /usr/share/dotnet
-        sudo df -h
+      - name: Free up space
+        if: matrix.config.host == 'ubuntu-latest'
+        run: |
+          pwd
+          sudo df -h
+          sudo find /opt -maxdepth 1 ! -name hostedtoolcache ! -name opt | sudo xargs rm -rf
+          sudo rm -rf /usr/share/dotnet
+          sudo df -h
 
-    - name: Install curl (windows)
-      if: matrix.config.host == 'windows-2019'
-      run: choco install curl
+      - name: Install curl (windows)
+        if: matrix.config.host == 'windows-2019'
+        run: choco install curl
 
-    - name: Get engine version
-      id: get_engine_version
-      run: |
-        value=`curl https://raw.githubusercontent.com/flutter/flutter/${{ matrix.channel }}/bin/internal/engine.version`
-        echo ::set-output name=engine_version::$value
-      shell: bash
+      - name: Get engine version
+        id: get_engine_version
+        run: |
+          value=`curl https://raw.githubusercontent.com/flutter/flutter/${{ matrix.channel }}/bin/internal/engine.version`
+          echo ::set-output name=engine_version::$value
+        shell: bash
 
-    - name: Create release
-      if: github.event_name != 'pull_request'
-      continue-on-error: true
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.PERMANENT_GITHUB_TOKEN }}
-      with:
-        tag_name: f-${{ steps.get_engine_version.outputs.engine_version }}
-        release_name: Flutter Engine ${{ steps.get_engine_version.outputs.engine_version }}
+      - name: Create release
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERMANENT_GITHUB_TOKEN }}
+        with:
+          tag_name: f-${{ steps.get_engine_version.outputs.engine_version }}
+          release_name: Flutter Engine ${{ steps.get_engine_version.outputs.engine_version }}
 
-    - name: Check release
-      if: github.event_name != 'pull_request'
-      id: release_check
-      run: |
-        url="https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/f-${{ steps.get_engine_version.outputs.engine_version }}"
-        header="Authorization: token ${{ secrets.PERMANENT_GITHUB_TOKEN }}"
+      - name: Check release
+        if: github.event_name != 'pull_request'
+        id: release_check
+        run: |
+          url="https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/f-${{ steps.get_engine_version.outputs.engine_version }}"
+          header="Authorization: token ${{ secrets.PERMANENT_GITHUB_TOKEN }}"
 
-        content=`curl --header "$header" $url`
-        echo $content
+          content=`curl --header "$header" $url`
+          echo $content
 
-        assets=`echo $content | jq .assets[].name`
-        echo $assets
+          assets=`echo $content | jq .assets[].name`
+          echo $assets
 
-        if echo $assets | grep -q ${{ matrix.config.host_tag }}-${{ matrix.config.tag }}.zip
-        then
-          echo Skipping build
-          echo ::set-output name=skip_build::true
-        fi
-      shell: bash
+          if echo $assets | grep -q ${{ matrix.config.host_tag }}-${{ matrix.config.tag }}.zip
+          then
+            echo Skipping build
+            echo ::set-output name=skip_build::true
+          fi
+        shell: bash
 
-    - name: Checkout
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
-      uses: actions/checkout@v1
+      - name: Checkout
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
+        uses: actions/checkout@v3
 
-    - name: Checkout (windows)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
-      run: git clone https://github.com/jslater89/flutter-rs-engine-builds.git C:\repo
+      - name: Checkout (windows)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
+        run: git clone https://github.com/${{github.repository}} C:\repo
 
-    - name: Install Python 3.x
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'macos-latest'
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
+      - name: Install Python 3.x
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'macos-latest'
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
 
-    - name: Install dependencies (ubuntu)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'ubuntu-latest'
-      run: sudo apt-get install patch tree zip
+      - name: Install dependencies (ubuntu)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'ubuntu-latest'
+        run: sudo apt-get install patch tree zip
 
-    - name: Install dependencies (macos)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'macos-latest'
-      run: brew install binutils gpatch tree
+      - name: Install dependencies (macos)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'macos-latest'
+        run: brew install binutils gpatch tree
 
-    - name: Install dependencies (windows)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
-      run: choco install patch tree zip
+      - name: Install dependencies (windows)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
+        run: choco install patch tree zip
 
-    - name: Install depot tools
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
-      run: ./fetch-depot-tools.sh
-      shell: bash
+      - name: Install depot tools
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
+        run: ./fetch-depot-tools.sh
+        shell: bash
 
-    - name: Install depot tools (windows)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
-      working-directory: C:\repo
-      run: ./fetch-depot-tools.sh
-      shell: bash
+      - name: Install depot tools (windows)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
+        working-directory: C:\repo
+        run: ./fetch-depot-tools.sh
+        shell: bash
 
-    - name: Download engine (windows)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
-      working-directory: C:\repo
-      run: ./fetch-engine.bat ${{ steps.get_engine_version.outputs.engine_version }}
+      - name: Download engine (windows)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
+        working-directory: C:\repo
+        run: ./fetch-engine.bat ${{ steps.get_engine_version.outputs.engine_version }}
 
-    - name: Download engine (macos + ubuntu)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
-      run: ./fetch-engine.sh ${{ steps.get_engine_version.outputs.engine_version }}
-      shell: bash
+      - name: Download engine (macos + ubuntu)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
+        run: ./fetch-engine.sh ${{ steps.get_engine_version.outputs.engine_version }}
+        shell: bash
 
-    - name: Patch
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
-      run: ./patch-engine.sh
-      shell: bash
+      - name: Patch
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
+        run: ./patch-engine.sh
+        shell: bash
 
-    - name: Patch (windows)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
-      working-directory: C:\repo
-      run: ./patch-engine.sh
-      shell: bash
+      - name: Patch (windows)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
+        working-directory: C:\repo
+        run: ./patch-engine.sh
+        shell: bash
 
-    - name: Generate config
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
-      run: ./gn.sh ${{ matrix.config.gn }}
-      shell: bash
+      - name: Generate config
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
+        run: ./gn.sh ${{ matrix.config.gn }}
+        shell: bash
 
-    - name: Generate config (windows)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
-      working-directory: C:\repo
-      run: ./gn.sh ${{ matrix.config.gn }}
-      shell: bash
+      - name: Generate config (windows)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
+        working-directory: C:\repo
+        run: ./gn.sh ${{ matrix.config.gn }}
+        shell: bash
 
-    - name: Build
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
-      run: ./build.sh ${{ matrix.config.tag }}
-      shell: bash
+      - name: Build
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
+        run: ./build.sh ${{ matrix.config.tag }}
+        shell: bash
 
-    - name: Build (windows)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
-      working-directory: C:\repo
-      run: ./build.sh ${{ matrix.config.tag }}
-      shell: bash
+      - name: Build (windows)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
+        working-directory: C:\repo
+        run: ./build.sh ${{ matrix.config.tag }}
+        shell: bash
 
-    - name: Print out tree
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
-      run: tree ./engine/src/out/
-      shell: bash
+      - name: Print out tree
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
+        run: tree ./engine/src/out/
+        shell: bash
 
-    - name: Print out tree (windows)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
-      working-directory: C:\repo
-      run: tree ./engine/src/out/
-      shell: bash
+      - name: Print out tree (windows)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
+        working-directory: C:\repo
+        run: tree ./engine/src/out/
+        shell: bash
 
-    - name: Print release tree
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
-      run: tree ./engine_out/
-      shell: bash
+      - name: Print release tree
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
+        run: tree ./engine_out/
+        shell: bash
 
-    - name: Print release tree (windows)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
-      working-directory: C:\repo
-      run: tree ./engine_out/
-      shell: bash
+      - name: Print release tree (windows)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
+        working-directory: C:\repo
+        run: tree ./engine_out/
+        shell: bash
 
-    - name: Create release zip
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
-      run: cd engine_out && zip -qq -r ../${{ matrix.config.host_tag }}-${{ matrix.config.tag }}.zip ./*
-      shell: bash
+      - name: Create release zip
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host != 'windows-2019'
+        run: cd engine_out && zip -qq -r ../${{ matrix.config.host_tag }}-${{ matrix.config.tag }}.zip ./*
+        shell: bash
 
-    - name: Create release zip (windows)
-      if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
-      working-directory: C:\repo
-      run: cd engine_out && zip -qq -r ../${{ matrix.config.host_tag }}-${{ matrix.config.tag }}.zip ./*
-      shell: bash
+      - name: Create release zip (windows)
+        if: steps.release_check.outputs.skip_build != 'true' && matrix.config.host == 'windows-2019'
+        working-directory: C:\repo
+        run: cd engine_out && zip -qq -r ../${{ matrix.config.host_tag }}-${{ matrix.config.tag }}.zip ./*
+        shell: bash
 
-    - name: Upload release asset
-      if: steps.release_check.outputs.skip_build != 'true' && github.event_name != 'pull_request' && matrix.config.host != 'windows-2019'
-      uses: softprops/action-gh-release@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.PERMANENT_GITHUB_TOKEN }}
-      with:
-        tag_name: f-${{ steps.get_engine_version.outputs.engine_version }}
-        name: Flutter ${{ steps.get_engine_version.outputs.engine_version }}
-        files: ${{ matrix.config.host_tag }}-${{ matrix.config.tag }}.zip
+      - name: Upload release asset
+        if: steps.release_check.outputs.skip_build != 'true' && github.event_name != 'pull_request' && matrix.config.host != 'windows-2019'
+        uses: softprops/action-gh-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERMANENT_GITHUB_TOKEN }}
+        with:
+          tag_name: f-${{ steps.get_engine_version.outputs.engine_version }}
+          name: Flutter ${{ steps.get_engine_version.outputs.engine_version }}
+          files: ${{ matrix.config.host_tag }}-${{ matrix.config.tag }}.zip
 
-    - name: Upload release asset (windows)
-      if: steps.release_check.outputs.skip_build != 'true' && github.event_name != 'pull_request' && matrix.config.host == 'windows-2019'
-      uses: softprops/action-gh-release@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.PERMANENT_GITHUB_TOKEN }}
-      with:
-        tag_name: f-${{ steps.get_engine_version.outputs.engine_version }}
-        name: Flutter ${{ steps.get_engine_version.outputs.engine_version }}
-        files: C:\repo\${{ matrix.config.host_tag }}-${{ matrix.config.tag }}.zip # hope this works!
+      - name: Upload release asset (windows)
+        if: steps.release_check.outputs.skip_build != 'true' && github.event_name != 'pull_request' && matrix.config.host == 'windows-2019'
+        uses: softprops/action-gh-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERMANENT_GITHUB_TOKEN }}
+        with:
+          tag_name: f-${{ steps.get_engine_version.outputs.engine_version }}
+          name: Flutter ${{ steps.get_engine_version.outputs.engine_version }}
+          files: C:\repo\${{ matrix.config.host_tag }}-${{ matrix.config.tag }}.zip # hope this works!

--- a/patch-engine.sh
+++ b/patch-engine.sh
@@ -10,5 +10,7 @@ INCBIN(Icudtl, \"${PWD}/engine/src/third_party/icu/flutter/icudtl.dat\");
 " >> engine/src/flutter/shell/platform/embedder/embedder.cc
 cp switches.patch engine/src/flutter/shell/common/
 (cd engine/src/flutter/shell/common && patch -i switches.patch)
+echo 'patch switches.cc successfully'
 cp embedder.patch engine/src/flutter/shell/platform/embedder/
 (cd engine/src/flutter/shell/platform/embedder/ && patch -i embedder.patch)
+echo 'patch BUILD.gn successfully'


### PR DESCRIPTION
The repository url used at the jobs of windows platform might be wrong. I made a little change(line 108) that will always use the repository which the job is running on. This change takes effect on my fork(at least it can build all 12 kinds of products correctly).

Here is the successful running result: https://github.com/Ink-33/engine-builds/actions/runs/2630991534
https://github.com/Ink-33/engine-builds/releases

ps: English is not my native language. Please excuse typing errors, thx.